### PR TITLE
Update cache address platform for darwin

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -30,7 +30,7 @@ async function downloadCabalCache(
         return cabalCacheExtractedFolder;
     } else if (process.platform === "darwin") {
         const cabalCachePath = await downloadTool(
-            `${downloadPrefix}/cabal-cache-x86_64-darwin.tar.gz`
+            `${downloadPrefix}/cabal-cache-arm64-darwin.tar.gz`
         );
         const cabalCacheExtractedFolder = await tc.extractTar(cabalCachePath);
         return cabalCacheExtractedFolder;


### PR DESCRIPTION
`macos-latest` GHA runner now uses `arm64` architecture, as a result the format of the URL for the tarballs for darwin in the releases of `haskell/cabal-cache` changed, see: https://github.com/haskell/cabal-cache/releases/

As a result the action `action-works/cabal-cache-s3` now fails, because it tries to get the URL from the wrong address, see:
https://github.com/input-output-hk/hedgehog-extras/actions/runs/13811858000/job/38635071048?pr=72

This PR tries to address this, but I am not familiar about how the action works, so it may be necessary to do more things, please check before merging and feel free to update the source fork.